### PR TITLE
Fix: Address UI/UX issues from your feedback (batch 3)

### DIFF
--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -284,7 +284,8 @@ body.pink-mode .task-list li.task-completed:hover {
 }
 
 #dashboardRankChartContainer { 
-    min-height: 250px; /* Adjusted height */
+    min-height: 250px; /* Base minimum height */
+    max-height: 350px; /* Max height for mobile and default */
     position: relative; 
     margin-top: 20px; /* Adjusted margin */
     padding: 15px; 

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -71,9 +71,9 @@
     .google-nav {
         position: static; /* Sidebar becomes part of the layout flow */
         left: auto; /* Reset fixed positioning effect */
-        height: auto; /* Content dictates height */
+        height: calc(100vh - 57px); /* Fill available height below header */
         width: 250px; /* Defined width */
-        /* transition: none; /* Will be overridden for collapse/expand */
+        overflow-y: auto; /* Allow sidebar to scroll its own content if needed */
         z-index: auto; /* Reset z-index */
         border-top: none; /* If it had one for fixed positioning */
         transform: none; /* Ensure it's not translated off-screen if that was used */
@@ -81,6 +81,7 @@
         /* Ensure padding and border are part of the main style for open state */
         padding: 15px; 
         border-right: 1px solid var(--current-border-color);
+        /* position: static; is inherited or correctly set by default for block in flex */
     }
     
     /* .sidebar-visible is for mobile overlay, not desktop push state */


### PR DESCRIPTION
- Changed mobile navigation menu icon from hamburger to kebab icon (three vertical dots), including an 'X' transformation for the active state.
- Limited the height of the dashboard rank chart on mobile views to 350px to prevent excessive elongation and improve usability.
- Fixed a bug where switching from mobile to desktop view via browser developer tools could cause an infinitely scrolling page. This was addressed by setting an explicit height and overflow handling for the desktop sidebar.